### PR TITLE
WalkerSim walkers will now be assigned entity IDs aligned with entitygroup tag restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.9.4 (ongoing)
-
+- Fix: Zombie spawning now obeys tags of biome spawner
+- Fix: Zombies killed are removed from the active list, reducing excessive logging and correctly respawning zombies.
 # 0.9.3
 - Fix: Flock processors always navigating towards the center.
 

--- a/Mod/Mod.cs
+++ b/Mod/Mod.cs
@@ -247,6 +247,9 @@ namespace WalkerSim
 
             var simulation = Simulation.Instance;
 
+            // Don't allocate unless there are actual dead agents.
+            List<Agent> deadAgents = null;
+
             foreach (var kv in simulation.Active)
             {
                 var agent = kv.Value;
@@ -260,7 +263,11 @@ namespace WalkerSim
                 if (IsEntityDead(entity, agent.EntityId))
                 {
                     // Mark as dead so it will be sweeped.
-                    simulation.MarkAgentDead(agent);
+                    if (deadAgents == null)
+                    {
+                        deadAgents = new List<Agent>();
+                    }
+                    deadAgents.Add(agent);
                 }
                 else
                 {
@@ -268,6 +275,15 @@ namespace WalkerSim
                     var newPos = entity.GetPosition();
                     agent.Position = VectorUtils.ToSim(newPos);
                     agent.Position.Validate();
+                }
+            }
+
+            // Remove dead agents.
+            if (deadAgents != null)
+            {
+                foreach (var agent in deadAgents)
+                {
+                    simulation.MarkAgentDead(agent);
                 }
             }
         }

--- a/Mod/Mod.cs
+++ b/Mod/Mod.cs
@@ -252,7 +252,7 @@ namespace WalkerSim
                 var agent = kv.Value;
                 if (agent.EntityId == -1)
                 {
-                    Logging.Debug("Agent has no entity id, skipping.");
+                    Logging.Debug("Agent has no entity id, skipping. Agent state: {0}", agent.CurrentState);
                     continue;
                 }
 

--- a/Mod/SpawnManager.cs
+++ b/Mod/SpawnManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
-using static SleeperVolume;
 
 namespace WalkerSim
 {
@@ -70,8 +69,6 @@ namespace WalkerSim
             );
 
             var biomeData = world.Biomes.GetBiome(biomeId);
-
-
 
             if (BiomeSpawningClass.list.TryGetValue(biomeData.m_sBiomeName, out BiomeSpawnEntityGroupList biomeList))
             {

--- a/Mod/SpawnManager.cs
+++ b/Mod/SpawnManager.cs
@@ -109,7 +109,7 @@ namespace WalkerSim
                 }
 
                 groupsEnabledMap.TryGetValue(chunk.Key, out groupsEnabledFlags);
-                Logging.Info("ChunkFlags generated: {0}", groupsEnabledFlags);
+                Logging.Debug("ChunkFlags generated: {0}", groupsEnabledFlags);
 
                 for (int i = 0; i < maxAttempts; i++)
                 {

--- a/Mod/SpawnManager.cs
+++ b/Mod/SpawnManager.cs
@@ -1,10 +1,16 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
+using static SleeperVolume;
 
 namespace WalkerSim
 {
     internal class SpawnManager
     {
         static int _lastClassId = -1;
+
+        static List<PrefabInstance> spawnPIs = new List<PrefabInstance>();
+
+        static Dictionary<long, int> groupsEnabledMap = new Dictionary<long, int>();
 
         static private bool CanSpawnZombie()
         {
@@ -50,17 +56,22 @@ namespace WalkerSim
         static private int GetEntityClassId(Chunk chunk, UnityEngine.Vector3 worldPos)
         {
             var world = GameManager.Instance.World;
+            int worldX = Mathf.FloorToInt(worldPos.x);
+            int worldZ = Mathf.FloorToInt(worldPos.z);
+
             if (world == null)
             {
                 return -1;
-            }
+            }   
 
             var biomeId = chunk.GetBiomeId(
-                World.toBlockXZ(Mathf.FloorToInt(worldPos.x)),
-                World.toBlockXZ(Mathf.FloorToInt(worldPos.z))
+                World.toBlockXZ(worldX),
+                World.toBlockXZ(worldZ)
             );
 
             var biomeData = world.Biomes.GetBiome(biomeId);
+
+
 
             if (BiomeSpawningClass.list.TryGetValue(biomeData.m_sBiomeName, out BiomeSpawnEntityGroupList biomeList))
             {
@@ -69,6 +80,40 @@ namespace WalkerSim
 
                 var maxAttempts = System.Math.Min(biomeList.list.Count, 10);
                 var lastPick = -1;
+
+                int groupsEnabledFlags = 0;
+
+                Logging.Debug("Are POIs checked for chunk? {0}", groupsEnabledMap.ContainsKey(chunk.Key));
+
+                // Only once per each chunk, check the tags of the POIs around that chunk
+                if (!groupsEnabledMap.ContainsKey(chunk.Key))
+                {
+                    FastTags<TagGroup.Poi> fastTags = FastTags<TagGroup.Poi>.none;
+                    Logging.Debug("About to get POIs");
+                    world.GetPOIsAtXZ(worldX + 16, worldX + 80 - 16, worldZ + 16, worldZ + 80 - 16, spawnPIs);
+                    Logging.Debug("Got {0} POIs", spawnPIs.Count);
+                    for (int j = 0; j < spawnPIs.Count; j++)
+                    {
+                        // build list of tags for POIs around chunk
+                        PrefabInstance prefabInstance = spawnPIs[j];
+                        fastTags |= prefabInstance.prefab.Tags;
+                    }
+                    bool isEmpty = fastTags.IsEmpty;
+                    for (int k = 0; k < biomeList.list.Count; k++)
+                    {
+                        // build bit mask for enabling groups. If the chunk tag list contains a value in the noTags set in the spawn group, disable it. If the chunk tag list has any tags, make sure the chunk has them too
+                        BiomeSpawnEntityGroupData biomeSpawnEntityGroupData = biomeList.list[k];
+                        if ((biomeSpawnEntityGroupData.POITags.IsEmpty || biomeSpawnEntityGroupData.POITags.Test_AnySet(fastTags)) && (isEmpty || biomeSpawnEntityGroupData.noPOITags.IsEmpty || !biomeSpawnEntityGroupData.noPOITags.Test_AnySet(fastTags)))
+                        {
+                            groupsEnabledFlags |= 1 << k;
+                        }
+                    }
+                    groupsEnabledMap.Add(chunk.Key, groupsEnabledFlags);
+                }
+
+                groupsEnabledMap.TryGetValue(chunk.Key, out groupsEnabledFlags);
+                Logging.Info("ChunkFlags generated: {0}", groupsEnabledFlags);
+
                 for (int i = 0; i < maxAttempts; i++)
                 {
                     var randomPick = gameRandom.RandomRange(0, biomeList.list.Count);
@@ -81,7 +126,14 @@ namespace WalkerSim
                     lastPick = randomPick;
                     var group = biomeList.list[randomPick];
 
-                    if (group.daytime != eDaytime)
+                    // check the group enabled bit mask against the current pick
+                    if ((groupsEnabledFlags & (1 << randomPick)) == 0)
+                    {
+                        Logging.Debug("Group Disabled: {0}", group.entityGroupName);
+                        continue;
+                    }
+
+                    if (group.daytime != eDaytime && group.daytime != EDaytime.Any)
                     {
                         continue;
                     }

--- a/WalkerSim/Simulation.Active.cs
+++ b/WalkerSim/Simulation.Active.cs
@@ -32,6 +32,7 @@ namespace WalkerSim
 
         public void MarkAgentDead(Agent agent)
         {
+            _state.Active.Remove(agent.EntityId);
             agent.ResetSpawnData();
 
             if (_state.Config.RespawnPosition == Config.WorldLocation.None)

--- a/WalkerSim/Simulation.Logic.cs
+++ b/WalkerSim/Simulation.Logic.cs
@@ -52,6 +52,7 @@ namespace WalkerSim
                     }
                     else if (agent.CurrentState == Agent.State.Respawning)
                     {
+                        Logging.Debug("agent being respawned");
                         RespawnAgent(agent);
                     }
 


### PR DESCRIPTION
- Entity IDs will now align with tags defined in the entity groups for each biome. No more Ferals + Cops on day one in the forest!
took me all day to figure this out 😭 but! Works very nicely now! Should make for a much more reasonable early game!

EDIT: Accidentally added another feature to this branch - thats what I get for pushing to main 🤦 
Agents will now be removed from the active agent list when marked dead. This prevents console spam.
Also added some extra debug messages.

Good feature might be adding a debug flag to the xml or something and only printing debug messages if that flag is on.