### PR TITLE
Random road points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /Viewer/obj
 /Editor/obj
 /Editor/.vs
+Binaries/
+packages/
+Tests/obj/

--- a/.idea/.idea.WalkerSim2/.idea/.gitignore
+++ b/.idea/.idea.WalkerSim2/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/.idea.WalkerSim2.iml
+/projectSettingsUpdater.xml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.WalkerSim2/.idea/.name
+++ b/.idea/.idea.WalkerSim2/.idea/.name
@@ -1,0 +1,1 @@
+WalkerSim2

--- a/.idea/.idea.WalkerSim2/.idea/indexLayout.xml
+++ b/.idea/.idea.WalkerSim2/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/WalkerSim/Roads.cs
+++ b/WalkerSim/Roads.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace WalkerSim
 {
@@ -20,7 +23,8 @@ namespace WalkerSim
         RoadType[] _data;
         int _width;
         int _height;
-
+        
+         readonly WalkerSim.Random PRNG = new WalkerSim.Random(1);
         public struct RoadPoint
         {
             public static RoadPoint Invalid = new RoadPoint()
@@ -162,7 +166,8 @@ namespace WalkerSim
             var cellY = y / CellSize;
 
             float closestDist = float.MaxValue;
-
+            var closestPoints = new List<RoadPoint>();
+            closestPoints.Add(closest);
             // Iterate through neighboring cells (3x3 grid)
             for (int offsetY = -1; offsetY <= 1; offsetY++)
             {
@@ -188,17 +193,23 @@ namespace WalkerSim
                             }
 
                             var dist = Vector3.DistanceSqr(new Vector3(x, y), new Vector3(point.X, point.Y));
-                            if (dist < closestDist)
+                            if (dist == closestDist)
+                            {
+                                closestPoints.Add(point);
+                            }
+                            else if (dist < closestDist)
                             {
                                 closestDist = dist;
-                                closest = point;
+                                closestPoints.Clear();
+                                closestPoints.Add(point);
                             }
                         }
                     }
                 }
             }
-
-            return closest;
+            
+             var p = PRNG.Next(closestPoints.Count);
+             return closestPoints[p];
         }
 
     }


### PR DESCRIPTION
I noticed that having agents stick to roads would often lead to an upwards/north distribution. This is happening because the cells are always iterated in the same order and the if there are multiple equally close road cells, i will always pick the upper one. This pr tries to fix this behavior by taking a random of the closest points.
I made a video showing the difference:
[Video showing difference](https://www.youtube.com/watch?v=6TjU_Mpvl64)

Could use help making the code prettier xD